### PR TITLE
Fix syntax issue in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,5 @@
   ],
   "labels": [
     "[bot] renovate"
-  ],
+  ]
 }


### PR DESCRIPTION
This pull request includes a minor change to the `renovate.json` file. The change involves removing an unnecessary comma from the end of the "labels" array. 

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L12-R12): Removed an unnecessary comma from the end of the "labels" array.